### PR TITLE
Fix Timetag to time.Time conversion

### DIFF
--- a/types.go
+++ b/types.go
@@ -15,8 +15,9 @@ const (
 )
 
 // Immediately is a specific Timetag representing immediate execution of a Bundle.
-const Immediately = Timetag(0x01)
-const timeTo1970 = 2208988800
+const Immediately = Timetag(1)
+const timeTo1970 = 2208988800                         // Source: RFC 868
+const nsPerFraction = float64(0.23283064365386962891) // 1e9/(2^32)
 
 // Package is the generalization of both package types.
 type Package interface {
@@ -41,7 +42,14 @@ func (m *Message) String() string {
 	return fmt.Sprintf("%s: %v", m.Address, m.Arguments)
 }
 
-// Timetag represents the time since 1900-01-01 00:00.
+// Timetag represents the time since 1900-01-01 00:00. From the spec:
+//
+// Time tags are represented by a 64 bit fixed point number. The first 32 bits
+// specify the number of seconds since midnight on January 1, 1900, and the
+// last 32 bits specify fractional parts of a second to a precision of about
+// 200 picoseconds. This is the representation used by Internet NTP
+// timestamps. The time tag value consisting of 63 zero bits followed by a one
+// in the least signifigant bit is a special case meaning “immediately.”
 type Timetag uint64
 
 // Bundle is the data structure for OSC bundle packets.
@@ -71,15 +79,25 @@ func getPadBytes(length int) int {
 // Fractions will return the fractions of the Timetag with picoseconds
 // resolution.
 func (tt Timetag) Fractions() uint32 {
-	return uint32(tt & 0x00000000FFFFFFFF)
+	return uint32(tt)
 }
 
 // Seconds will return the seconds since the Timetag beginning.
 func (tt Timetag) Seconds() uint32 {
-	return uint32(tt & 0xFFFFFFFF00000000 >> 32)
+	return uint32(tt >> 32)
 }
 
 // Time will return the Timetag as a Golang time.Time type.
 func (tt Timetag) Time() time.Time {
-	return time.Unix(int64(tt.Seconds()-timeTo1970), int64(tt.Fractions()))
+	if uint64(tt) == 1 {
+		// Means "immediately". It cannot occur otherwise as timetag == 0 gets
+		// converted to January 1, 1900 while time.Time{} means year 1 in Go.
+		// Use the time.Time.IsZero() method to detect it.
+		return time.Time{}
+	}
+
+	return time.Unix(
+		int64(tt.Seconds())-timeTo1970,
+		int64(float64(tt.Fractions())*nsPerFraction),
+	).UTC()
 }

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,25 @@
+package gosc
+
+import (
+	"testing"
+	"time"
+)
+
+func tryTimetag(t *testing.T, a Timetag, b time.Time) {
+	if a.Time() != b {
+		t.Fatalf("failed timetag %x %v %v", a, a.Time(), b)
+	}
+}
+
+func TestTimetagToTime(t *testing.T) {
+	// 0*0.233ns = 0ns
+	tryTimetag(t, Timetag(0), time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC))
+	// "Immediately" special case
+	tryTimetag(t, Timetag(1), time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC))
+	// 2*0.233ns ~= 0ns
+	tryTimetag(t, Timetag(2), time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC))
+	// 5*0.233ns ~= 1ns
+	tryTimetag(t, Timetag(5), time.Date(1900, 1, 1, 0, 0, 0, 1, time.UTC))
+	// 1s
+	tryTimetag(t, Timetag(1<<32+0), time.Date(1900, 1, 1, 0, 0, 1, 0, time.UTC))
+}


### PR DESCRIPTION
The OSC spec seems unclear: the lower 32 bits of a timetag aren't nanoseconds, they are a fraction of a second. I don't use this library but I found it by accident, so I thought I'd contribute. I sent the same patch to [scgolang/osc](https://github.com/scgolang/osc/pull/13) yesterday. Another library had [the same issue](https://github.com/hypebeast/go-osc/issues/56).

Hoping this can be useful to someone. :) I just like OSC, I don't use the library. As such, those changes were not field tested. Please don't hesitate reviewing and doubting my changes.